### PR TITLE
Enable loadFromRemoteSources

### DIFF
--- a/StardewModdingAPI/App.config
+++ b/StardewModdingAPI/App.config
@@ -3,4 +3,7 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+    <runtime>
+        <loadFromRemoteSources enabled="true"/>
+    </runtime>
 </configuration>


### PR DESCRIPTION
Makes loading downloaded DLLs a little bit easier, sometimes they'll error unless you specifically unblock them - this fixes that.